### PR TITLE
Update python script and metadata for 2017 data format

### DIFF
--- a/metadata.md
+++ b/metadata.md
@@ -131,6 +131,21 @@ This metadata is collected from a variety of sources, in some cases verbatim. Se
 - `release_spin_rate` - rate of spin after ball is released
 - `release_extension` - how much closer, in feet, the pitch is released compared to the rubber. 
 - `game_pk` - related to the Game Day package
+- `pos1_person_id` - pitcher's MLB ID
+- `pos2_person_id.1` - catcher's MLB ID
+- `pos3_person_id` - first baseman's MLB ID
+- `pos4_person_id` - second basemen's MLB ID
+- `pos5_person_id` - third baseman's MLB ID
+- `pos6_person_id` - shortstop's MLB ID
+- `pos7_person_id` - left fielder's MLB ID
+- `pos8_person_id` - center fielder's MLB ID
+- `pos9_person_id` - right fielder's MLB ID
+- `estimated_ba_using_speedangle` - average BA on balls with a similar exit velocity and launch angle
+- `estimated_woba_using_speedangle` - average wOBA on balls with a similar exit velocity and launch angle
+- `woba_value` - potentially the wOBA numerator?
+- `woba_denom` - potentially the wOBA denominator?
+- `babip_value` - something having to do with batting average on balls in play?
+- `iso_value` - something having to do with isolated power?
 
 #### References 
 

--- a/metadata.md
+++ b/metadata.md
@@ -1,6 +1,10 @@
 ## Baseball Savant Data Scraping
 
 #### Metadata
+#### NOTE pitch_id was removed in 2017 and is no longer available
+#### See this article for an explanation of the changes and information about merging
+#### new data with old data:
+#### http://www.hardballtimes.com/research-notebook-new-format-for-statcast-data-export-at-baseball-savant/
 
 This metadata is collected from a variety of sources, in some cases verbatim. See References.  
 
@@ -21,11 +25,10 @@ This metadata is collected from a variety of sources, in some cases verbatim. Se
 	- `SC` Screwball
 	- `SI` Sinker
 	- `SL` Slider
-- `pitch_id`	- unique identifier for the pitch in a given game
 - `game_date`	- date game was played
-- `start_speed` - pitch speed in miles per hour, measured at the initial point, y0. The field y0 has changed at times but is not available on this source. 
-- `x0` - horizontal position of the pitch at y0
-- `z0` - vertical position of the pitch at y0
+- `release_speed` - pitch speed in miles per hour, measured at the initial point, y0. The field y0 has changed at times but is not available on this source. (renamed start_speed; note that it is now measured by StatCast, not PITCHf/x
+- `release_pos_x` - horizontal position of the pitch at y0 (renamed x0)
+- `release_pos_z` - vertical position of the pitch at y0 (renamed z0)
 - `batter_name` - name of batter
 - `batter` - MLB ID of batter	
 - `pitcher` - MLB ID of pitcher	
@@ -75,9 +78,9 @@ This metadata is collected from a variety of sources, in some cases verbatim. Se
 	- Swinging Strike
 	- Swinging Strike (Blocked)
 - `spin_dir` - direction of spin in degrees
-- `spin_rate` - ball spin in revolutions per minute
-- `break_angle`	- the angle, in degrees, from vertical to the straight line path from the release point to where the pitch crossed the front of home plate, as seen from the catcher’s/umpire’s perspective
-- `break_length` - the measurement of the greatest distance, in inches, between the trajectory of the pitch at any point between the release point and the front of home plate, and the straight line path from the release point and the front of home plate 	
+- `spin_rate_deprecated` - ball spin in revolutions per minute (renamed spin_rate)
+- `break_angle_deprecated` - the angle, in degrees, from vertical to the straight line path from the release point to where the pitch crossed the front of home plate, as seen from the catcher’s/umpire’s perspective (renamed break_angle)
+- `break_length_deprecated` - the measurement of the greatest distance, in inches, between the trajectory of the pitch at any point between the release point and the front of home plate, and the straight line path from the release point and the front of home plate (renamed break_length)
 - `zone` - mapping of where ball crosses the plate from the pitcher's perspective. The zone is divided up into a 3x3 grid. Zone 1 is high and inside to a left handed hitter, Zone 4 middle and inside, and Zone 9 would be low and outside. Zones 11, 12, 13, and 14 represent areas outside of the strike zone and follow the same left to right counting scheme.  
 - `des` - play-by-play description of the result of the at bat
 - `game_type` - type of game: `S` spring training, `R` regular season, `P` playoffs	
@@ -98,8 +101,8 @@ This metadata is collected from a variety of sources, in some cases verbatim. Se
 - `game_year` - year of game date	
 - `pfx_x` - the horizontal movement, in inches, of the pitch between the release point and home plate, as compared to a theoretical pitch thrown at the same speed with no spin-induced movement. This parameter is measured at y=40 feet regardless of the y0 value.	
 - `pfx_z` - the vertical movement, in inches, of the pitch between the release point and home plate, as compared to a theoretical pitch thrown at the same speed with no spin-induced movement. This parameter is measured at y=40 feet regardless of the y0 value.	
-- `px` - the left/right distance, in feet, of the pitch from the middle of the plate as it crossed home plate. The PITCHf/x coordinate system is oriented to the catcher’s/umpire’s perspective, with distances to the right being positive and to the left being negative.	
-- `pz` - the height of the pitch in feet as it crossed the front of home plate.	
+- `plate_x` - the left/right distance, in feet, of the pitch from the middle of the plate as it crossed home plate. The PITCHf/x coordinate system is oriented to the catcher’s/umpire’s perspective, with distances to the right being positive and to the left being negative. (renamed px)
+- `plate_z` - the height of the pitch in feet as it crossed the front of home plate. (renamed pz)	
 - `on_3b` - MLB ID of runner on third base. Null if no runner.
 - `on_2b` - MLB ID of runner on second base. Null if no runner.
 - `on_1b` - MLB ID of runner on first base. Null if no runner.
@@ -108,9 +111,9 @@ This metadata is collected from a variety of sources, in some cases verbatim. Se
 - `inning_topbot` - half inning indicator: `top` top or `bot` bottom
 - `hc_x` - horizontal location of batted ball (0 to 250). Bottom left corner of top down view of baseball field is (0, -250). Top right is (250, 0).
 - `hc_y` - shallow/deep location of batted ball (-250 to 0). Bottom left corner of top down view of baseball field is (0, -250). Top right is (250, 0).
-- `tfs` - UTC time
-- `tfs_zulu` - UTC timestamp	
-- `catcher` - MLB ID of catcher
+- `tfs_deprecated` - UTC time (renamed tfs)
+- `tfs_zulu_deprecated` - UTC timestamp	(renamed tfs_zulu)
+- `pos2_person_id` - MLB ID of catcher (renamed catcher)
 - `umpire` - MLB ID of umpire	
 - `sv_id` - a date/time stamp of when the PITCHf/x tracking system first detected the pitch in the air, it is in the format YYMMDD_hhmmss	
 - `vx0` - initial horizontal velociy of pitch in feet per second	
@@ -122,8 +125,8 @@ This metadata is collected from a variety of sources, in some cases verbatim. Se
 - `sz_top` - the distance in feet from the ground to the top of the current batter’s rulebook strike zone as measured from the video by the PITCHf/x operator. The operator sets a line at the batter’s belt as he settles into the hitting position, and the PITCHf/x software adds four inches up for the top of the zone.
 - `sz_bot` - the distance in feet from the ground to the bottom of the current batter’s rulebook strike zone. The PITCHf/x operator sets a line at the hollow of the knee for the bottom of the zone.	
 - `hit_distance_sc` - hit distance in feet
-- `hit_speed` - exit velocity in mph	
-- `hit_angle` - angle of ball hit in degrees
+- `launch_speed` - exit velocity in mph	(renamed hit_speed)
+- `launch_angle` - angle of ball hit in degrees (renamed hit_angle)
 - `effective_speed` - perceived velocity of pitch in mph
 - `release_spin_rate` - rate of spin after ball is released
 - `release_extension` - how much closer, in feet, the pitch is released compared to the rubber. 

--- a/scraper.ipynb
+++ b/scraper.ipynb
@@ -16,6 +16,7 @@
     "   - Home/Away\n",
     "   - Outs\n",
     "   - Innings (1-9 and 10+)\n",
+    "   - Handedness (R for righty and L for lefty)\n",
     "    \n",
     "#### Output\n",
     "\n",
@@ -32,8 +33,6 @@
    },
    "outputs": [],
    "source": [
-    "import requests\n",
-    "import os\n",
     "import pandas as pd\n",
     "import sqlite3\n",
     "from tqdm import tqdm\n",
@@ -69,34 +68,47 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
     "# Year loop\n",
     "for year in tqdm(range(2008, 2017), desc = 'Years'):\n",
     "    # Team loop\n",
-    "    for team in teams:\n",
+    "    for team in tqdm(teams, desc = 'Teams', leave = False):\n",
     "        # Home/Away loop\n",
-    "        for home_away in loc:\n",
-    "            # Outs loop\n",
-    "            for outs in outl:\n",
-    "                # Inning loop\n",
-    "                for inning in range(1,11):\n",
-    "                    # Query link is based on loop input\n",
-    "                    link = 'https://baseballsavant.mlb.com/statcast_search/csv?all=true&hfPT=&hfZ=&hfGT=R%7CPO%7CS%7C&hfPR=&hfAB=&stadium=&hfBBT=&hfBBL=&hfC=&season=' + str(year) + '&player_type=batter&hfOuts=' + outs + '%7C&pitcher_throws=&batter_stands=&start_speed_gt=&start_speed_lt=&perceived_speed_gt=&perceived_speed_lt=&spin_rate_gt=&spin_rate_lt=&exit_velocity_gt=&exit_velocity_lt=&launch_angle_gt=&launch_angle_lt=&distance_gt=&distance_lt=&batted_ball_angle_gt=&batted_ball_angle_lt=&game_date_gt=&game_date_lt=&team=' + team + '&position=&hfRO=&home_road=' + home_away + '&hfInn=' + str(inning) + '%7C&min_pitches=0&min_results=0&group_by=name&sort_col=pitches&player_event_sort=start_speed&sort_order=desc&min_abs=0&xba_gt=&xba_lt=&px1=&px2=&pz1=&pz2=&ss_gt=&ss_lt=&is_barrel=&type=details&'\n",
-    "                    try:\n",
-    "                        # Read in query CSV as dataframe\n",
-    "                        data = pd.read_csv(link)\n",
-    "                    except HTTPError:\n",
-    "                        # If there is an error, sleep and try one more time\n",
-    "                        time.sleep(10)\n",
-    "                        # Read in query CSV as dataframe\n",
-    "                        data = pd.read_csv(link)\n",
-    "                    # Rename player_name to denote that it is the batter\n",
-    "                    data.rename(columns={'player_name' : 'batter_name'}, inplace=True)\n",
-    "                    # Append the dataframe to the data\n",
-    "                    pd.io.sql.to_sql(data, name = 'statcast', con = savant, if_exists='append')"
+    "        for home_away in tqdm(loc, desc = 'Location', leave = False):\n",
+    "            # Inning loop\n",
+    "            for inning in tqdm(range(1, 11), desc='Innings', leave=False):\n",
+    "                # Outs loop\n",
+    "                for outs in tqdm(outl, desc = 'Outs', leave = False):\n",
+    "                    # pitcher handedness\n",
+    "                    for throws in ['R', 'L']:\n",
+    "                        # Query link is based on loop input\n",
+    "                        link = 'https://baseballsavant.mlb.com/statcast_search/csv?all=true\\\n",
+    "                        &hfGT=R%7CPO%7CS%7C&hfPR=\\\n",
+    "                        &season=' + str(year) + '&player_type=batter\\\n",
+    "                        &hfOuts=' + outs + '%7C&team=' + team + '&position=&hfRO=\\\n",
+    "                        &home_road=' + home_away + '&hfInn=' + str(inning) + '%7C&min_pitches=0\\\n",
+    "                        &pitcher_throws=' + throws + '&min_results=0&group_by=name&sort_col=pitches\\\n",
+    "                        &player_event_sort=start_speed\\\n",
+    "                        &sort_order=desc&min_abs=0&xba_gt=&xba_lt=&px1=&px2=&pz1=&pz2=&ss_gt=&ss_lt=&is_barrel=&type=details&'\n",
+    "                        successful = False\n",
+    "                        backoff_time = 30\n",
+    "                        while not successful:\n",
+    "                            try:\n",
+    "                                # Read in query CSV as dataframe\n",
+    "                                data = pd.read_csv(link)\n",
+    "                                # Rename player_name to denote that it is the batter\n",
+    "                                data.rename(columns={'player_name': 'batter_name'}, inplace=True)\n",
+    "                                # Append the dataframe to the data\n",
+    "                                pd.io.sql.to_sql(data, name='statcast', con=savant, if_exists='append')\n",
+    "                                successful = True\n",
+    "                            except (HTTPError, sqlite3.OperationalError) as e:\n",
+    "                                # If there is an error backoff exponentially until there is no longer an error\n",
+    "                                for i in tqdm(range(1, backoff_time), desc=\"Backing off \" + str(backoff_time) + \" seconds for error \" + str(e) + \" at \" + str(year) + \" \" + outs + \" \" + team + \" \" + home_away + \" \" + str(inning), leave=False):\n",
+    "                                    time.sleep(1)\n",
+    "                                backoff_time = min(backoff_time * 2, 60*60)"
    ]
   },
   {
@@ -107,67 +119,32 @@
    },
    "outputs": [],
    "source": [
-    "# Delete any duplicate pitches\n",
-    "s = savant.cursor()\n",
-    "\n",
-    "s.execute('''DELETE FROM statcast WHERE rowid NOT IN (SELECT MIN(rowid) FROM statcast GROUP BY game_pk, pitch_id, game_year, inning, outs_when_up)''')\n",
-    "\n",
     "# Commit and close connection\n",
     "savant.commit() \n",
     "savant.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "# Final check to make sure there are no duplicates\n",
-    "sql = \"\"\"SELECT *,  COUNT(*)\n",
-    "FROM\n",
-    "    statcast\n",
-    "GROUP BY\n",
-    "    game_pk, pitch_id, game_year, inning, outs_when_up, away_team\n",
-    "HAVING \n",
-    "    COUNT(*) > 1\"\"\"\n",
-    "\n",
-    "df = pd.read_sql(sql, savant)\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [drei]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "Python [drei]"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/scraper.py
+++ b/scraper.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 '''
 Copyright (C) 2017
 Author: Alan Kessler
@@ -41,14 +42,13 @@ loc = ['Home', 'Road']
 
 # List of out combinations
 outl = ['0', '1', '2%7C3']
-
+alreadyPrinted = False
 # Year loop
 for year in tqdm(range(2008, 2017), desc = 'Years'):
     # Team loop
     for team in tqdm(teams, desc = 'Teams', leave = False):
         # Home/Away loop
         for home_away in tqdm(loc, desc = 'Location', leave = False):
-            # print "###\n### TEAM: " + team + "\n### " + home_away + "\n###"
             # Inning loop
             for inning in tqdm(range(1, 11), desc='Innings', leave=False):
                 # Outs loop
@@ -66,21 +66,22 @@ for year in tqdm(range(2008, 2017), desc = 'Years'):
                         &sort_order=desc&min_abs=0&xba_gt=&xba_lt=&px1=&px2=&pz1=&pz2=&ss_gt=&ss_lt=&is_barrel=&type=details&'
 
                         successful = False
-                        backoff_time = 10
+                        backoff_time = 30
                         while not successful:
                             try:
                                 # Read in query CSV as dataframe
+                                raise HTTPError(msg='Test error', url='http://fake.com', code=502, hdrs='', fp=None)
                                 data = pd.read_csv(link)
                                 # Rename player_name to denote that it is the batter
                                 data.rename(columns={'player_name': 'batter_name'}, inplace=True)
                                 # Append the dataframe to the data
-                                pd.io.sql.to_sql(data, name='statcast', con=savant, if_exists='append')
+                                # pd.io.sql.to_sql(data, name='statcast', con=savant, if_exists='append')
                                 successful = True
                             except (HTTPError, sqlite3.OperationalError) as e:
                                 # If there is an error, sleep and try one more time
-                                time.sleep(backoff_time)
+                                for i in tqdm(range(1, backoff_time), desc="Backing off " + str(backoff_time) + " seconds for error " + str(e) + " at " + str(year) + " " + outs + " " + team + " " + home_away + " " + str(inning), leave=False):
+                                    time.sleep(1)
                                 backoff_time = min(backoff_time * 2, 60*60)
-                                print "\n\n\n\nBacking off " + str(backoff_time) + " seconds for error " + str(e) + " at " + str(year) + " " + outs + " " + team + " " + home_away + " " + str(inning)
 
 # Commit and close connection
 savant.commit() 

--- a/scraper.py
+++ b/scraper.py
@@ -23,6 +23,8 @@ import pandas as pd
 import sqlite3
 from tqdm import tqdm
 import time
+from urllib2 import HTTPError
+
 
 # Connect to database
 savant = sqlite3.connect('BaseballSavant.db')
@@ -43,32 +45,42 @@ outl = ['0', '1', '2%7C3']
 # Year loop
 for year in tqdm(range(2008, 2017), desc = 'Years'):
     # Team loop
-    for team in teams:
+    for team in tqdm(teams, desc = 'Teams', leave = False):
         # Home/Away loop
-        for home_away in loc:
-            # Outs loop
-            for outs in outl:
-                # Inning loop
-                for inning in range(1,11):
-                    # Query link is based on loop input
-                    link = 'https://baseballsavant.mlb.com/statcast_search/csv?all=true&hfPT=&hfZ=&hfGT=R%7CPO%7CS%7C&hfPR=&hfAB=&stadium=&hfBBT=&hfBBL=&hfC=&season=' + str(year) + '&player_type=batter&hfOuts=' + outs + '%7C&pitcher_throws=&batter_stands=&start_speed_gt=&start_speed_lt=&perceived_speed_gt=&perceived_speed_lt=&spin_rate_gt=&spin_rate_lt=&exit_velocity_gt=&exit_velocity_lt=&launch_angle_gt=&launch_angle_lt=&distance_gt=&distance_lt=&batted_ball_angle_gt=&batted_ball_angle_lt=&game_date_gt=&game_date_lt=&team=' + team + '&position=&hfRO=&home_road=' + home_away + '&hfInn=' + str(inning) + '%7C&min_pitches=0&min_results=0&group_by=name&sort_col=pitches&player_event_sort=start_speed&sort_order=desc&min_abs=0&xba_gt=&xba_lt=&px1=&px2=&pz1=&pz2=&ss_gt=&ss_lt=&is_barrel=&type=details&'
-                    try:
-                        # Read in query CSV as dataframe
-                        data = pd.read_csv(link)
-                    except HTTPError:
-                        # If there is an error, sleep and try one more time
-                        time.sleep(10)
-                        # Read in query CSV as dataframe
-                        data = pd.read_csv(link)
-                    # Rename player_name to denote that it is the batter
-                    data.rename(columns={'player_name' : 'batter_name'}, inplace=True)
-                    # Append the dataframe to the data
-                    pd.io.sql.to_sql(data, name = 'statcast', con = savant, if_exists='append')
-                    
-# Delete any duplicate pitches
-s = savant.cursor()
+        for home_away in tqdm(loc, desc = 'Location', leave = False):
+            # print "###\n### TEAM: " + team + "\n### " + home_away + "\n###"
+            # Inning loop
+            for inning in tqdm(range(1, 11), desc='Innings', leave=False):
+                # Outs loop
+                for outs in tqdm(outl, desc = 'Outs', leave = False):
+                    # pitcher handedness
+                    for throws in ['R', 'L']:
+                        # Query link is based on loop input
+                        link = 'https://baseballsavant.mlb.com/statcast_search/csv?all=true\
+                        &hfGT=R%7CPO%7CS%7C&hfPR=\
+                        &season=' + str(year) + '&player_type=batter\
+                        &hfOuts=' + outs + '%7C&team=' + team + '&position=&hfRO=\
+                        &home_road=' + home_away + '&hfInn=' + str(inning) + '%7C&min_pitches=0\
+                        &pitcher_throws=' + throws + '&min_results=0&group_by=name&sort_col=pitches\
+                        &player_event_sort=start_speed\
+                        &sort_order=desc&min_abs=0&xba_gt=&xba_lt=&px1=&px2=&pz1=&pz2=&ss_gt=&ss_lt=&is_barrel=&type=details&'
 
-s.execute('''DELETE FROM statcast WHERE rowid NOT IN (SELECT MIN(rowid) FROM statcast GROUP BY game_pk, pitch_id, game_year, inning, outs_when_up)''')
+                        successful = False
+                        backoff_time = 10
+                        while not successful:
+                            try:
+                                # Read in query CSV as dataframe
+                                data = pd.read_csv(link)
+                                # Rename player_name to denote that it is the batter
+                                data.rename(columns={'player_name': 'batter_name'}, inplace=True)
+                                # Append the dataframe to the data
+                                pd.io.sql.to_sql(data, name='statcast', con=savant, if_exists='append')
+                                successful = True
+                            except (HTTPError, sqlite3.OperationalError) as e:
+                                # If there is an error, sleep and try one more time
+                                time.sleep(backoff_time)
+                                backoff_time = min(backoff_time * 2, 60*60)
+                                print "\n\n\n\nBacking off " + str(backoff_time) + " seconds for error " + str(e) + " at " + str(year) + " " + outs + " " + team + " " + home_away + " " + str(inning)
 
 # Commit and close connection
 savant.commit() 

--- a/scraper.py
+++ b/scraper.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 '''
 Copyright (C) 2017
 Author: Alan Kessler
@@ -18,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.'''
 
 # Baseball Savant Data Scraping
 
-import requests
-import os
 import pandas as pd
 import sqlite3
 from tqdm import tqdm
@@ -42,7 +39,6 @@ loc = ['Home', 'Road']
 
 # List of out combinations
 outl = ['0', '1', '2%7C3']
-alreadyPrinted = False
 # Year loop
 for year in tqdm(range(2008, 2017), desc = 'Years'):
     # Team loop
@@ -70,12 +66,11 @@ for year in tqdm(range(2008, 2017), desc = 'Years'):
                         while not successful:
                             try:
                                 # Read in query CSV as dataframe
-                                raise HTTPError(msg='Test error', url='http://fake.com', code=502, hdrs='', fp=None)
                                 data = pd.read_csv(link)
                                 # Rename player_name to denote that it is the batter
                                 data.rename(columns={'player_name': 'batter_name'}, inplace=True)
                                 # Append the dataframe to the data
-                                # pd.io.sql.to_sql(data, name='statcast', con=savant, if_exists='append')
+                                pd.io.sql.to_sql(data, name='statcast', con=savant, if_exists='append')
                                 successful = True
                             except (HTTPError, sqlite3.OperationalError) as e:
                                 # If there is an error, sleep and try one more time


### PR DESCRIPTION
On April 24, the format for output from baseball savant changed, and so this script needed to be modified to accommodate the changes (the best explanation of the changes I could find is [here](http://www.hardballtimes.com/research-notebook-new-format-for-statcast-data-export-at-baseball-savant/)).

I updated the script to add pitcher handedness as another parameter that is switched on, as baseball savant no longer was giving data for all requests broken down by team, inning, out, and location.  I'm guessing this is because the added columns increased the size of the retrieved data.  In any case, adding pitcher_throws as a parameter allowed the script to execute to completion.

I also updated the metadata to reflect removed columns, renamed columns, and new columns, with explanations I could find. I also added some more tqdm stuff to make the console output a little more useful, and a very basic exponential backoff to request retrying as I found the API often seemed to just get fed up with the frequency of requests.  In practice, when this happened 5 minutes seemed to be a magic number, but, since this could change without any notice, I decided to use a backoff strategy in case a request fails because of the network or in case they change the undocumented rate limiting.  Let me know if you have any questions - I was really excited to find your script and happy to update it to keep it working!